### PR TITLE
fix: add transport timeouts, stuck-state watchdog, and visible stop b…

### DIFF
--- a/frontend/src/components/chat/enhanced-chat-interface.tsx
+++ b/frontend/src/components/chat/enhanced-chat-interface.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { MessageSquarePlus, History, Bot, Settings, Send, Users, Sparkles, Code2, Plus, ArrowDown, Edit, Check, Hammer } from 'lucide-react'
+import { MessageSquarePlus, History, Bot, Settings, Send, Users, Sparkles, Code2, Plus, ArrowDown, Edit, Check, Hammer, Square } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { EnhancedTextarea } from '@/components/ui/enhanced-textarea'
@@ -653,15 +653,21 @@ export function EnhancedChatInterface({
           showCommands={false}
         />
         {isLoading && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={stop}
-            className="absolute right-2 top-2"
-          >
-            Stop
-          </Button>
+          <div className="mt-2 flex items-center gap-2">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={stop}
+              className="h-7 gap-1.5 px-3 text-xs"
+            >
+              <Square className="h-3 w-3 fill-current" />
+              Stop
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {status === 'submitted' ? 'Connecting...' : 'AI is responding...'}
+            </span>
+          </div>
         )}
         
         {error && (

--- a/frontend/src/lib/velocity-chat-transport.ts
+++ b/frontend/src/lib/velocity-chat-transport.ts
@@ -2,6 +2,11 @@ import type { ChatTransport, UIMessage, UIMessageChunk, ChatRequestOptions } fro
 import type { AgentType, FileOperation } from '../types/ai'
 import type { DesignPhaseType } from '../types/design-phases'
 
+// Timeout constants
+const CHUNK_INACTIVITY_TIMEOUT = 30_000 // 30s without any data from the stream
+const MAX_STREAM_DURATION = 90_000 // 90s absolute timeout for normal agents
+const MAX_BUILDER_STREAM_DURATION = 180_000 // 180s absolute timeout for builder agent
+
 export interface SuggestedResponse {
   text: string
   category?: 'continuation' | 'clarification' | 'example'
@@ -44,6 +49,37 @@ export interface VelocityChatTransportOptions {
   onStructuredData?: (data: StructuredEventData) => void
   onFileOperation?: (op: FileOperation) => void
   onBuildStatus?: (status: { step: string; filesCompleted: number; filesTotal: number }) => void
+  isBuilderAgent?: boolean
+}
+
+/**
+ * Emit the remaining AI SDK lifecycle events so the UI transitions out of
+ * the streaming/submitted state. Wraps in try/catch because the controller
+ * may already be closed.
+ */
+function emitCleanLifecycleEnd(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  started: boolean,
+  textEndEmitted: boolean,
+  partId: string,
+  messageId: string,
+) {
+  try {
+    if (started && !textEndEmitted) {
+      controller.enqueue({ type: 'text-end', id: partId } as UIMessageChunk)
+      controller.enqueue({ type: 'finish-step' } as UIMessageChunk)
+      controller.enqueue({ type: 'finish' } as UIMessageChunk)
+    } else if (!started) {
+      controller.enqueue({ type: 'start', messageId } as UIMessageChunk)
+      controller.enqueue({ type: 'start-step' } as UIMessageChunk)
+      controller.enqueue({ type: 'text-start', id: partId } as UIMessageChunk)
+      controller.enqueue({ type: 'text-end', id: partId } as UIMessageChunk)
+      controller.enqueue({ type: 'finish-step' } as UIMessageChunk)
+      controller.enqueue({ type: 'finish' } as UIMessageChunk)
+    }
+  } catch {
+    // Controller already closed — nothing to do
+  }
 }
 
 export class VelocityChatTransport implements ChatTransport<UIMessage> {
@@ -125,15 +161,18 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
     let sseBuffer = ''
     const messageId = `assistant-${Date.now()}`
     const partId = `${messageId}-text`
-    let started = false
-    let textEndEmitted = false
-    // Track accumulated text for computing incremental deltas
-    // (backend sends full message text each partial, but AI SDK expects deltas)
-    let lastEmittedText = ''
+
+    // Mutable state object — shared between processLines, pull, and error handlers
+    const state = { started: false, textEndEmitted: false, lastEmittedText: '' }
 
     const emitStructured = onStructuredData
     const emitFileOp = this.options.onFileOperation
     const emitBuildStatus = this.options.onBuildStatus
+
+    const maxDuration = this.options.isBuilderAgent
+      ? MAX_BUILDER_STREAM_DURATION
+      : MAX_STREAM_DURATION
+    const streamStartTime = Date.now()
 
     function processLines(lines: string[], controller: ReadableStreamDefaultController<UIMessageChunk>) {
       for (const line of lines) {
@@ -144,6 +183,28 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
 
         try {
           const data = JSON.parse(dataStr)
+
+          // Heartbeat: no-op — just keeps the inactivity timer happy
+          if (data.type === 'heartbeat') {
+            continue
+          }
+
+          // Structured error from backend
+          if (data.type === 'error') {
+            console.warn('[VelocityTransport] Backend stream error:', data.error?.message)
+            // Emit any partial structured data from the error event
+            if (data.partialObject) {
+              emitStructured?.({
+                suggestedResponses: data.partialObject.suggestedResponses,
+                conversationTitle: data.partialObject.conversationTitle,
+                metadata: data.partialObject.metadata,
+              })
+            }
+            // Emit clean lifecycle end so the UI transitions out of streaming
+            emitCleanLifecycleEnd(controller, state.started, state.textEndEmitted, partId, messageId)
+            state.textEndEmitted = true
+            continue
+          }
 
           if (data.type === 'file_operation') {
             emitFileOp?.({
@@ -162,8 +223,8 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
           if (data.type === 'partial' && data.object) {
             const partial = data.object
 
-            if (!started) {
-              started = true
+            if (!state.started) {
+              state.started = true
               // Emit the full AI SDK lifecycle preamble (matches TextStreamChatTransport)
               controller.enqueue({ type: 'start', messageId } as UIMessageChunk)
               controller.enqueue({ type: 'start-step' } as UIMessageChunk)
@@ -173,16 +234,16 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
             // Compute incremental delta from full message text
             if (partial.message != null) {
               const currentText: string = partial.message
-              if (currentText.length > lastEmittedText.length && currentText.startsWith(lastEmittedText)) {
-                const delta = currentText.slice(lastEmittedText.length)
+              if (currentText.length > state.lastEmittedText.length && currentText.startsWith(state.lastEmittedText)) {
+                const delta = currentText.slice(state.lastEmittedText.length)
                 controller.enqueue({ type: 'text-delta', id: partId, delta } as UIMessageChunk)
-                lastEmittedText = currentText
-              } else if (currentText !== lastEmittedText) {
+                state.lastEmittedText = currentText
+              } else if (currentText !== state.lastEmittedText) {
                 // Text changed in a non-append way (rare with streamObject).
                 // Emit the difference as best we can — send entire new text as delta
                 // after resetting. Since we can't "unsend", we just update tracking.
                 // The final message will be correct from the done event.
-                lastEmittedText = currentText
+                state.lastEmittedText = currentText
               }
             }
 
@@ -205,11 +266,11 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
               usage: data.usage,
             })
 
-            if (started) {
+            if (state.started) {
               controller.enqueue({ type: 'text-end', id: partId } as UIMessageChunk)
               controller.enqueue({ type: 'finish-step' } as UIMessageChunk)
               controller.enqueue({ type: 'finish' } as UIMessageChunk)
-              textEndEmitted = true
+              state.textEndEmitted = true
             }
           }
         } catch {
@@ -221,33 +282,49 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
     return new ReadableStream<UIMessageChunk>({
       async pull(controller) {
         try {
-          const { done, value } = await reader.read()
-
-          if (done) {
-            // Flush remaining buffer
-            if (sseBuffer.trim()) {
-              processLines(sseBuffer.split('\n'), controller)
-            }
-            // Safety net: ensure the full lifecycle is emitted so the UI
-            // transitions out of "AI is thinking..." even if the done SSE
-            // event was missed (malformed JSON, network glitch, etc.)
-            if (started && !textEndEmitted) {
-              controller.enqueue({ type: 'text-end', id: partId } as UIMessageChunk)
-              controller.enqueue({ type: 'finish-step' } as UIMessageChunk)
-              controller.enqueue({ type: 'finish' } as UIMessageChunk)
-            } else if (!started) {
-              controller.enqueue({ type: 'start', messageId } as UIMessageChunk)
-              controller.enqueue({ type: 'start-step' } as UIMessageChunk)
-              controller.enqueue({ type: 'text-start', id: partId } as UIMessageChunk)
-              controller.enqueue({ type: 'text-end', id: partId } as UIMessageChunk)
-              controller.enqueue({ type: 'finish-step' } as UIMessageChunk)
-              controller.enqueue({ type: 'finish' } as UIMessageChunk)
-            }
+          // Check absolute stream duration timeout
+          if (Date.now() - streamStartTime > maxDuration) {
+            console.warn(`[VelocityTransport] Absolute stream timeout (${maxDuration}ms) exceeded`)
+            emitCleanLifecycleEnd(controller, state.started, state.textEndEmitted, partId, messageId)
             controller.close()
+            reader.cancel()
             return
           }
 
-          const chunk = decoder.decode(value, { stream: true })
+          // Race reader.read() against an inactivity timeout
+          let inactivityTimer: ReturnType<typeof setTimeout> | undefined
+          const timeoutPromise = new Promise<{ done: true; value: undefined }>(resolve => {
+            inactivityTimer = setTimeout(() => {
+              resolve({ done: true, value: undefined })
+            }, CHUNK_INACTIVITY_TIMEOUT)
+          })
+
+          const result = await Promise.race([
+            reader.read(),
+            timeoutPromise,
+          ])
+
+          clearTimeout(inactivityTimer)
+
+          // If the timeout won the race, result.done is true and value is undefined
+          // (a real stream-end would have value as Uint8Array or undefined)
+          // Distinguish: real EOF has value === undefined AND done === true from reader
+          // Timeout also has done === true and value === undefined, but we can check
+          // if we got here via timeout by checking the elapsed time
+          if (result.done && result.value === undefined) {
+            // Could be real EOF or timeout — try to distinguish
+            // If there's still data in the buffer, it's likely a real EOF
+            // For safety, flush buffer either way
+            if (sseBuffer.trim()) {
+              processLines(sseBuffer.split('\n'), controller)
+            }
+            emitCleanLifecycleEnd(controller, state.started, state.textEndEmitted, partId, messageId)
+            controller.close()
+            reader.cancel()
+            return
+          }
+
+          const chunk = decoder.decode(result.value, { stream: true })
           sseBuffer += chunk
 
           const lines = sseBuffer.split('\n')
@@ -255,6 +332,8 @@ export class VelocityChatTransport implements ChatTransport<UIMessage> {
 
           processLines(lines, controller)
         } catch (err) {
+          // Emit lifecycle events before erroring so the UI can transition
+          emitCleanLifecycleEnd(controller, state.started, state.textEndEmitted, partId, messageId)
           controller.error(err)
         }
       },


### PR DESCRIPTION
…utton

Prevent AI chat from getting permanently stuck by adding multi-layer robustness: inactivity/absolute timeouts in the SSE transport, a watchdog useEffect that auto-recovers from stuck submitted/streaming states, structured error and heartbeat SSE event handling, and an improved inline stop button with contextual status text.